### PR TITLE
rename changeItem to checkItem

### DIFF
--- a/src/resolvers.js
+++ b/src/resolvers.js
@@ -10,7 +10,7 @@ export const typeDefs = gql`
   }
 
   extend type Mutation {
-    changeItem(id: ID!): Boolean
+    checkItem(id: ID!): Boolean
     deleteItem(id: ID!): Boolean
     addItem(text: String!): Item
   }


### PR DESCRIPTION
Здравствуйте!
Мне кажется у вас здесь ошибка.
И здесь тоже:
https://webdevblog.ru/apollo-upravlenie-sostoyaniem-v-prilozheniyah-vue/

В типе мы указываем `changeItem`, однако повсеместно используем `checkItem`.

Однако, несмотря на это код работает. Что пугает еще больше.
Неужели нет способа отслеживать корректность?